### PR TITLE
Support CMake instead of direct Makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /*.a
 /sha3sum
 /sha3test
+build
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(sha3iuf)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_subdirectory(lib)
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
+if(BUILD_EXAMPLE)
+  add_subdirectory(example)
+endif()
+
+if(BUILD_FUZZER)
+  add_subdirectory(fuzz)
+endif()

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,40 @@
-.POSIX:
-CC = c99
-CFLAGS = -std=c99 -Wall -Wextra -Wpedantic -O2 -g
-LDFLAGS =
-LDLIBS =
-PREFIX = /usr/local
+.PHONY: build-static-lib-debug
+build-static-lib-debug:
+	cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Debug
+	cmake --build build
 
-all: libsha3.a sha3sum sha3test
+.PHONY: build-static-lib-release
+build-static-lib-release:
+	cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
+	cmake --build build
 
-.SUFFIXES: .c .o
-.c.o:
-	$(CC) -c $(CFLAGS) -o $@ $<
+.PHONY: build-shared-lib-debug
+build-shared-lib-debug:
+	cmake -S. -Bbuild -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug
+	cmake --build build
 
-libsha3.a: sha3.o
-	ar rsv $@ sha3.o
+.PHONY: build-shared-lib-release
+build-shared-lib-release:
+	cmake -S. -Bbuild -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
+	cmake --build build
 
-sha3sum: sha3.o sha3sum.o
-	$(CC) $(LDFLAGS) -o $@ sha3.o sha3sum.o $(LDLIBS)
+.PHONY: build-example
+build-example:
+	cmake -S. -Bbuild -DBUILD_EXAMPLE=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
+	cmake --build build
 
-sha3fuzz: sha3.c fuzz/sha3fuzz.c
-	clang -g --std=c99 -fsanitize=fuzzer,address -O0 -I . -o $@ $^
+.PHONY: run-tests
+run-tests:
+	cmake -S. -Bbuild -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
+	cmake --build build
+	./build/test/sha3iuf_test
 
-sha3test: sha3.o sha3test.o
-	$(CC) $(LDFLAGS) -o $@ sha3.o sha3test.o $(LDLIBS)
+.PHONY: run-fuzzer
+run-fuzzer:
+	cmake -S. -Bbuild -DBUILD_FUZZER=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
+	cmake --build build
+	./build/test/sha3iuf_fuzz ./fuzz/seeds -max_total_time=100
 
-check: sha3test
-	./sha3test
-
+.PHONY: clean
 clean:
-	rm -f *.o libsha3.a sha3sum sha3test sha3fuzz
-
-install:
-	mkdir -p $(DESTDIR)$(PREFIX)/include \
-		$(DESTDIR)$(PREFIX)/lib \
-		$(DESTDIR)$(PREFIX)/bin
-	install sha3.h $(DESTDIR)$(PREFIX)/include
-	install -m 755 libsha3.a $(DESTDIR)$(PREFIX)/lib
-	install -m 755 sha3sum $(DESTDIR)$(PREFIX)/bin
-
-uninstall:
-	rm -f \
-		$(DESTDIR)$(PREFIX)/include/sha3.h \
-		$(DESTDIR)$(PREFIX)/lib/libsha3.a \
-		$(DESTDIR)$(PREFIX)/bin/sha3sum
-
-.PHONY: all check clean install uninstall
+	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ build-example:
 	cmake -S. -Bbuild -DBUILD_EXAMPLE=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 	cmake --build build
 
-.PHONY: run-tests
-run-tests:
+.PHONY: test
+test:
 	cmake -S. -Bbuild -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 	cmake --build build
 	./build/test/sha3iuf_test

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Include this project somewhere in your project (like `ext/SHA3IUF`) and add this
 ## Testing & Fuzzing
 
     // Run tests
-    $ make clean run-tests
+    $ make clean test
 
     // Run fuzzer (powered by [LibFuzzer](https://llvm.org/docs/LibFuzzer.html))
     $ make clean run-fuzzer

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The purpose of this project is:
   * how small can the state be (224 bytes on a 64-bit system for a unified SHA-3 algorithm)
   * what is the incremental cost of adding e.g. SHA3-384 to a SHA3-256 implementation?
 
-The implementation is written in C and uses `uint64_t` types to manage the SHA-3 state. The code will compile and run on 64-bit and 32-bit architectures (`gcc` and `gcc -m32` on `x86_64` were tested).
+The implementation is written in C and uses `uint64_t` types to manage the SHA-3 state. The code will compile and run on 64-bit and 32-bit architectures.
 
 [fips202_standard]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf "FIPS 202 standard"
 
@@ -25,7 +25,7 @@ This is a clean-room implementation of IUF API for SHA3. The `keccakf()` is base
 
 ## Overview of the API
 
-Let's hash 'abc' with SHA3-256 using two methods: single buffer (but using IUF paradigm), and using the IUF API. 
+Let's hash 'abc' with SHA3-256 using two methods: single buffer (but using IUF paradigm), and using the IUF API.
 
     sha3_context c;
     uint8_t *hash;
@@ -58,36 +58,48 @@ There is also a single-call hashing API:
 
 Call `sha3_SetFlags(&c, SHA3_FLAGS_KECCAK)` immediately after `sha3_InitX` or no later than `sha3_Finalize`. This change cannot be undone for the given hash context.
 
-## Building
+## Building the library
 
-    $ make
+    // Builds a static library (change 'release' to 'debug' when developing)
+    $ make clean build-static-lib-release
 
-See `Makefile` for details. See also below for specific examples.
+    // Builds a shared library (change 'release' to 'debug' when developing)
+    $ make clean build-shared-lib-release
 
-## Self-tests
+## Linking with CMake
 
-    $ make test
-    Keccak-256 tests passed OK
-    SHA3-256, SHA3-384, SHA3-512 tests passed OK
+Include this project somewhere in your project (like `ext/SHA3IUF`) and add this to your `CMakeLists.txt`:
 
-or 
+    add_subdirectory(ext/SHA3IUF)
 
-    $ make CFLAGS=-m32 LDFLAGS=-m32 test
-    Keccak-256 tests passed OK
-    SHA3-256, SHA3-384, SHA3-512 tests passed OK
+    // Then link it to a target with
+    target_link_libraries(${PROJECT_NAME} sha3iuf_lib)
+
+## Testing & Fuzzing
+
+    // Run tests
+    $ make clean run-tests
+
+    // Run fuzzer (powered by [LibFuzzer](https://llvm.org/docs/LibFuzzer.html))
+    $ make clean run-fuzzer
+
+## Example Project
 
 There is also `sha3sum` test program that takes following parameters:
 
-    sha3sum 256|384|512 file_path 
+    sha3sum 256|384|512 file_path
 
 or for Keccak version:
 
-    sha3sum 256|384|512 -k file_path 
+    sha3sum 256|384|512 -k file_path
+
+Build it with `make clean build-example`
 
 ### SHA-3 / Linux sha3sum example
 
     $ touch empty.txt
-    $ gcc -Wall sha3.c sha3sum.c -o sha3sum && ./sha3sum 256 empty.txt
+    $ make clean build-example
+    $ ./build/example/sha3iuf_example 256 empty.txt
     a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a  empty.txt
 
 Compare with Linux `sha3sum`:
@@ -115,12 +127,6 @@ This corresponds to the result obtained in Solidity JavaScript test framework.
 * `sha3_InitX` also works as Reset (zeroization) of the hash context; no Free function is needed;
 
 See [`sha3.h`](sha3.h) for the exact interface.
-
-## API fuzzing
-
-    $ fuzz/run.sh
-
-The fuzzing script expects clang installed.
 
 ## Credits
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(sha3iuf_example)
+
+add_executable(${PROJECT_NAME} "main.c")
+target_link_libraries(${PROJECT_NAME} sha3iuf_lib)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror -pedantic)

--- a/example/main.c
+++ b/example/main.c
@@ -11,7 +11,6 @@
  * ---------------------------------------------------------------------- */
 
 #include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -22,7 +21,7 @@
 #include <stdlib.h>
 #include <sys/mman.h>
 
-#include "sha3.h"
+#include "sha3iuf/sha3.h"
 
 static void help(const char *argv0) {
     printf("To call: %s 256|384|512 [-k] file_path.\n", argv0);
@@ -136,3 +135,4 @@ int main(int argc, char *argv[])
 
     return 0;
 }
+

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(sha3iuf_fuzz)
+
+add_executable(${PROJECT_NAME} "fuzz.cc")
+target_link_libraries(${PROJECT_NAME} PRIVATE sha3iuf_lib
+                                              -fsanitize=fuzzer,address)
+
+target_compile_options(${PROJECT_NAME} PRIVATE -g -O0 -Wall -Wextra -Werror
+                                               -pedantic)

--- a/fuzz/fuzz.cc
+++ b/fuzz/fuzz.cc
@@ -1,12 +1,7 @@
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
+#include "sha3iuf/sha3.h"
 
-#include "sha3.h"
-
-int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+int LLVMFuzzerTestOneInput(const uint8_t *Data, uint32_t Size) {
 	sha3_context c;
-	const void *hash;
 	uint8_t b;
 	uint8_t buf[512/8];
 	unsigned is_keccak;
@@ -19,6 +14,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 	Data ++;
 
 	is_keccak = b & (1<<2);
+	enum SHA3_FLAGS flags = (enum SHA3_FLAGS)(Data[1]);
 
 	switch(b & 3) {
 		case 0:
@@ -32,8 +28,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 			break;
 		case 3:
 			if(Size >= 2)
-				sha3_HashBuffer((unsigned)Data[0] << 1, 
-						Data[1]/*SHA3_FLAGS_KECCAK or NONE*/, 
+				sha3_HashBuffer((unsigned)Data[0] << 1,
+						flags/*SHA3_FLAGS_KECCAK or NONE*/,
 						Data + 2, Size-2, buf, sizeof(buf));
 			return 0;
 	}
@@ -42,8 +38,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 		sha3_SetFlags( &c, SHA3_FLAGS_KECCAK );
 
 	sha3_Update(&c, Data, Size);
-	hash = sha3_Finalize(&c);
+	sha3_Finalize(&c);
 
 	return 0;
 }
-

--- a/fuzz/run.sh
+++ b/fuzz/run.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-THIS_SCRIPT=$(readlink -f $0)
-P=`dirname $THIS_SCRIPT`
-TOP=`dirname $P`
-
-cd  $TOP
-make sha3fuzz && ./sha3fuzz $P/seeds -max_total_time=100

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(sha3iuf_lib)
+
+set(BUILD_TYPE
+    "STATIC"
+    CACHE STRING "Build type")
+
+if(BUILD_SHARED_LIBS)
+  add_library(${PROJECT_NAME} SHARED "src/sha3.c")
+else()
+  add_library(${PROJECT_NAME} STATIC "src/sha3.c")
+endif()
+target_include_directories(${PROJECT_NAME} PUBLIC "include")
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror -pedantic)

--- a/lib/include/sha3iuf/sha3.h
+++ b/lib/include/sha3iuf/sha3.h
@@ -5,6 +5,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stddef.h>
 
 /* -------------------------------------------------------------------------
  * Works when compiled for either 32-bit or 64-bit targets, optimized for 
@@ -62,7 +63,7 @@ void sha3_Init512(void *priv);
 
 enum SHA3_FLAGS sha3_SetFlags(void *priv, enum SHA3_FLAGS);
 
-void sha3_Update(void *priv, void const *bufIn, uint32_t len);
+void sha3_Update(void *priv, void const *bufIn, size_t len);
 
 void const *sha3_Finalize(void *priv);
 

--- a/lib/include/sha3iuf/sha3.h
+++ b/lib/include/sha3iuf/sha3.h
@@ -1,5 +1,8 @@
-#ifndef SHA3_H
-#define SHA3_H
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stdint.h>
 
@@ -59,7 +62,7 @@ void sha3_Init512(void *priv);
 
 enum SHA3_FLAGS sha3_SetFlags(void *priv, enum SHA3_FLAGS);
 
-void sha3_Update(void *priv, void const *bufIn, size_t len);
+void sha3_Update(void *priv, void const *bufIn, uint32_t len);
 
 void const *sha3_Finalize(void *priv);
 
@@ -70,4 +73,6 @@ sha3_return_t sha3_HashBuffer(
     const void *in, unsigned inBytes, 
     void *out, unsigned outBytes );     /* up to bitSize/8; truncation OK */
 
+#ifdef __cplusplus
+}
 #endif

--- a/lib/src/sha3.c
+++ b/lib/src/sha3.c
@@ -16,11 +16,9 @@
  * Aug 2015. Andrey Jivsov. crypto@brainhub.org
  * ---------------------------------------------------------------------- */
 
-#include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 
-#include "sha3.h"
+#include "sha3iuf/sha3.h"
 
 #define SHA3_ASSERT( x )
 #define SHA3_TRACE( format, ...)
@@ -155,16 +153,16 @@ sha3_SetFlags(void *priv, enum SHA3_FLAGS flags)
 
 
 void
-sha3_Update(void *priv, void const *bufIn, size_t len)
+sha3_Update(void *priv, void const *bufIn, uint32_t len)
 {
     sha3_context *ctx = (sha3_context *) priv;
 
     /* 0...7 -- how much is needed to have a word */
     unsigned old_tail = (8 - ctx->byteIndex) & 7;
 
-    size_t words;
+    uint32_t words;
     unsigned tail;
-    size_t i;
+    uint32_t i;
 
     const uint8_t *buf = bufIn;
 

--- a/lib/src/sha3.c
+++ b/lib/src/sha3.c
@@ -153,14 +153,14 @@ sha3_SetFlags(void *priv, enum SHA3_FLAGS flags)
 
 
 void
-sha3_Update(void *priv, void const *bufIn, uint32_t len)
+sha3_Update(void *priv, void const *bufIn, size_t len)
 {
     sha3_context *ctx = (sha3_context *) priv;
 
     /* 0...7 -- how much is needed to have a word */
     unsigned old_tail = (8 - ctx->byteIndex) & 7;
 
-    uint32_t words;
+    size_t words;
     unsigned tail;
     uint32_t i;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(sha3iuf_test)
+
+add_executable(${PROJECT_NAME} "test.c")
+target_link_libraries(${PROJECT_NAME} sha3iuf_lib)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror -pedantic)

--- a/test/test.c
+++ b/test/test.c
@@ -57,13 +57,12 @@
  */
 
 #include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 
-#include "sha3.h"
+#include "sha3iuf/sha3.h"
 
 int
-main()
+main(void)
 {
     uint8_t buf[200];
     sha3_context c;
@@ -372,3 +371,4 @@ main()
 
     return 0;
 }
+


### PR DESCRIPTION
Hey guys. Thanks for this project. This PR keeps the same commands but adds support for CMake to make the code portable and easy to implement in CMake projects.

Also, I've added support for C++ projects through `extern "C"`.

And finally I switched all `size_t` usages to `uint32_t` to have the code portable since [size_t is defined differently](https://stackoverflow.com/questions/36594569/which-header-should-i-include-for-size-t) for C and C++.

The Makefile is now used as purely as task runner to invoke CMake. See the README for more info.

Much appreciated again